### PR TITLE
Replace find invocation, stylistic cleanup, exit

### DIFF
--- a/tools/ebuild_files_depends/ebuild_files_depends.pl
+++ b/tools/ebuild_files_depends/ebuild_files_depends.pl
@@ -1,60 +1,80 @@
 #!/usr/bin/env perl
 
 ### This script is intended to produce data for use in troubleshooting
-### ebuilds on funtoo, and should be triggered using the 
+### ebuilds on funtoo, and should be triggered using the
 ### post_src_prepare hook in /etc/portage/bashrc
 
 use strict;
 use warnings;
 
+use English qw(-no_match_vars);
+use File::Find;
+
+our $VERSION = 0.0.1;
 
 my $modified_ebuild = replace_ebuild_vars( get_ebuild() );
-my $build_dir       = $ENV{"PORTAGE_BUILDDIR"};
-my @file_list       = `find "$build_dir/files/" -type f`;
+my $build_dir       = $ENV{'PORTAGE_BUILDDIR'};
+my @file_list;
+find(
+    sub {
+        if ( !-f ) {
+            return;
+        }
+        else {
+            push @file_list, $File::Find::name;
+        }
+    },
+    "$build_dir/files/"
+);
+
+## If there's no files, there's nothing to do, so exit
+if ( !scalar @file_list ) {
+    exit 0;
+}
 
 print @{ get_patch_files( $modified_ebuild, \@file_list ) };
 
-
 ## get_ebuild function accepts a path to an ebuild file and
 ## returns it's contents as a string
-sub get_ebuild{
-	open (my $fh, '<', $ENV{EBUILD}) or die "could not open ebuild file";
-	my @ebuild_lines = <$fh>;
-	close $fh;
-	return join '',@ebuild_lines;
+sub get_ebuild {
+    open my $fh, '<', $ENV{EBUILD}
+        or die "Could not open ebuild file $ENV{EBUILD}: $ERRNO\n";
+    my @ebuild_lines = <$fh>;
+    close $fh or die "Unable to close filehandle: $ERRNO\n";
+    return join q(), @ebuild_lines;
 }
 
 ## replace_ebuild_vars function accepts a string that is the contents
 ## of an ebuild and returns a string that has all the associated
 ## keys from the env replaced with their values in the same string
 sub replace_ebuild_vars {
-	my $string = shift;
-	
-	foreach my $key (keys %ENV){
-		# print "$key = $ENV{$key}\n";
-		$string =~ s/\$\{\Q$key\E\}/$ENV{$key}/;
-		$string =~ s/[\"\']//;
-	}
-	
-	return $string;
+    my $string = shift;
+
+    foreach my $key ( keys %ENV ) {
+
+        $string =~ s/\$[{] \Q$key\E [}]/$ENV{$key}/xms;
+        $string =~ s/[\"\']//xms;
+    }
+
+    return $string;
 }
 
 ## This function accepts a string that is a modified ebuild
-## and a reference to an array of files 
+## and a reference to an array of files
 ## and returns a list of patch files found in it
-sub get_patch_files{
-	my $ebuild = shift;
-	my $file_list_ref = shift;
-	my @found_files;
-	
-	foreach my $filename (@{$file_list_ref}) {
-		chomp $filename;
-		
-		if (index($ebuild,$filename)) {
-			my $path_end = substr $filename, length($build_dir) + 1;
-			$filename = "$ENV{CATEGORY}/$ENV{PN}/$path_end";
-			push (@found_files, "$filename\n");
-		}
-	}
-	return \@found_files;	
+sub get_patch_files {
+    my $ebuild        = shift;
+    my $file_list_ref = shift;
+    my @found_files;
+
+    foreach my $filename ( @{$file_list_ref} ) {
+        chomp $filename;
+
+        if ( index $ebuild, $filename ) {
+            my $path_end = substr $filename, length($build_dir) + 1;
+            $filename = "$ENV{CATEGORY}/$ENV{PN}/$path_end";
+            push @found_files, "$filename\n";
+        }
+    }
+    return \@found_files;
 }


### PR DESCRIPTION
Replaces the `find` invocation with the pure-Perl File::Find. Also adjusted some of the existing style to be more in line with Perl::Critic and included a little additional error-handling as well as a graceful exit if no files are found. With any luck, I didn't even break anything, but it would be a good idea to double-check that the $key regex still works.